### PR TITLE
Fix data binding

### DIFF
--- a/front/elements/elements.py
+++ b/front/elements/elements.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
     get_args,
     get_origin,
+    Sequence,
 )
 from front.data_binding import BoundData, ValueNotSet
 from i2 import Sig
@@ -159,9 +160,12 @@ class InputBase(FrontComponentBase):
         self._init_none_value()
 
     def on_change(self):
-        value = self.value.get()
-        if self.on_value_change and value is not ValueNotSet:
-            call_forgivingly(self.on_value_change, self.value.get())
+        if (
+            self.on_value_change
+            and (view_value := self._create_bound_data(self.view_key).get())
+            is not ValueNotSet
+        ):
+            call_forgivingly(self.on_value_change, view_value)
 
     def post_render(self, render_result):
         self.value.set(render_result)
@@ -386,7 +390,7 @@ SELECT_BOX_DFLT_INDEX = 0
 
 @dataclass
 class SelectBoxBase(InputBase):
-    options: Union[Iterable, Callable] = None
+    options: Union[Sequence, Callable] = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -412,7 +416,7 @@ class SelectBoxBase(InputBase):
         options = self._ensure_options()
         return options[SELECT_BOX_DFLT_INDEX] if options else None
 
-    def _ensure_options(self):
+    def _ensure_options(self) -> Sequence:
         return self.options() if callable(self.options) else self.options
 
 

--- a/front/elements/elements.py
+++ b/front/elements/elements.py
@@ -392,8 +392,7 @@ SELECT_BOX_DFLT_INDEX = 0
 class SelectBoxBase(InputBase):
     options: Union[Sequence, Callable] = None
 
-    def __post_init__(self):
-        super().__post_init__()
+    def pre_render(self):
         self.options = self.options or []
         options = self._ensure_options()
         if not options:


### PR DESCRIPTION
There is a bug causing data binding value updates to occur 2 render frames after the users initial selection and the select box options are incorrect.

`InputBase.on_change` change from `value = self.value.get()` to using `view_value = self._create_bound_data(self.view_key).get()` which is set by `streamlit`. `on_change` is called before `post_render` sets new value.

In `SelectBoxBase`, moved setting options from `__post_init__` to `pre_render` to allow time for the `on_change` effects to resolve before querying the new options.

Updated `options` typing hints from `Iterable` --> `Sequence` to account for `__getitem__`