### PR TITLE
enable TextInputBase "type" option for passwords

### DIFF
--- a/front/elements/elements.py
+++ b/front/elements/elements.py
@@ -348,6 +348,8 @@ class MultiSourceInputBase(InputBase):
 
 @dataclass
 class TextInputBase(InputBase):
+    type: str = None
+
     @property
     def _dflt_view_value(self):
         return ''


### PR DESCRIPTION
Allow type "password"

Part of: https://github.com/otosense/opus/issues/82